### PR TITLE
Support for Multi-platform images with GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "🤖 Dependencies"
+  - package-ecosystem: "docker"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "🤖 Dependencies"
+  - package-ecosystem: "npm"
+    schedule:
+      interval: "daily"
+    labels:
+      - "🤖 Dependencies"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,66 @@
+name: CI/CD Docker Build/Publish
+
+on:
+  push:
+    branches:
+      - "main"
+    paths-ignore:
+      - "**.md"
+      - LICENSE
+      - "compose.yml"
+      - ".github/dependabot.yml"
+  pull_request:
+    branches:
+      - "*"
+  workflow_dispatch:
+  release:
+    types: [published, edited]
+
+jobs:
+  build-and-publish-image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Generate image tags based on semver
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ghcr.io/lllllllillllllillll/DweebUI
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}
+            type=semver,pattern={{major}}.{{minor}}
+
+      # Setup QEMU and Buildx for Multi-platform Support
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Only login to Registry if not running in a Pull Request
+      - name: Login to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Build image and only publish if not a Pull Request
+      - name: Build and Publish Docker Image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          target: release
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
- The following CI file will build and publish the image for `linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6`
- Added dependabot to track NPM, Docker, and Github Actions dependencies
- For now the CI process will publish the images to Github Container Registry `ghcr.io`. If you are happy with that support for Docker Hub can be added easily

Fixes #15 